### PR TITLE
Fix SourceLink and update documentation

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) Solid Token (https://www.solidtoken.nl)
+Copyright © Solid Token (https://www.solidtoken.nl)
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -5,13 +5,13 @@
 [![Azure Build](https://img.shields.io/azure-devops/build/solidtoken/GitHub/8.svg)](https://solidtoken.visualstudio.com/GitHub/_build/latest?definitionId=8&branchName=master) 
 [![NuGet Package](https://img.shields.io/nuget/v/SolidToken.SpecFlow.DependencyInjection.svg)](https://www.nuget.org/packages/SolidToken.SpecFlow.DependencyInjection)
 
-SpecFlow plugin for using Microsoft.Extensions.DependencyInjection as a dependency injection framework.
-
-Based on https://github.com/gasparnagy/SpecFlow.Autofac ([Apache License 2.0](https://github.com/gasparnagy/SpecFlow.Autofac/blob/master/LICENSE))
+SpecFlow plugin that enables to use Microsoft.Extensions.DependencyInjection for resolving test dependencies.
 
 Currently supports:
-* [SpecFlow v3.0](https://www.nuget.org/packages/SpecFlow/3.0)
-* [Microsoft.Extensions.DependencyInjection v2.2](https://www.nuget.org/packages/Microsoft.Extensions.DependencyInjection/2.2)
+* [SpecFlow v3.0 or above](https://www.nuget.org/packages/SpecFlow/3.0)
+* [Microsoft.Extensions.DependencyInjection v2.1 or above](https://www.nuget.org/packages/Microsoft.Extensions.DependencyInjection/2.1)
+
+Based on https://github.com/gasparnagy/SpecFlow.Autofac (now [part of SpecFlow](https://github.com/SpecFlowOSS/SpecFlow/tree/master/Plugins/SpecFlow.Autofac.SpecFlowPlugin)).
 
 ## Usage
 

--- a/SpecFlow.DependencyInjection/SpecFlow.DependencyInjection.csproj
+++ b/SpecFlow.DependencyInjection/SpecFlow.DependencyInjection.csproj
@@ -3,14 +3,14 @@
     <TargetFrameworks>netstandard2.0</TargetFrameworks>
     <PackageId>SolidToken.SpecFlow.DependencyInjection</PackageId>
     <Product>SpecFlow.DependencyInjection</Product>
-    <Description>SpecFlow plugin for using Microsoft.Extensions.DependencyInjection as a dependency injection framework.</Description>
+    <Description>SpecFlow plugin that enables to use Microsoft.Extensions.DependencyInjection for resolving test dependencies.</Description>
     <Authors>Solid Token</Authors>
     <Company>Solid Token</Company>
-    <Copyright>Copyright (c) Solid Token (https://www.solidtoken.nl)</Copyright>
+    <Copyright>Copyright © Solid Token</Copyright>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PackageProjectUrl>https://github.com/solidtoken/SpecFlow.DependencyInjection</PackageProjectUrl>
     <PackageIconUrl>https://avatars0.githubusercontent.com/u/413381</PackageIconUrl>
-    <PackageTags>microsoft;dependency-injection;specflow;specflow-plugin</PackageTags>
+    <PackageTags>specflow;plugin;microsoft;dependencyinjection;di</PackageTags>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <RepositoryType>git</RepositoryType>
     <RepositoryUrl>https://github.com/solidtoken/SpecFlow.DependencyInjection.git</RepositoryUrl>

--- a/SpecFlow.DependencyInjection/SpecFlow.DependencyInjection.csproj
+++ b/SpecFlow.DependencyInjection/SpecFlow.DependencyInjection.csproj
@@ -1,8 +1,10 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0</TargetFrameworks>
-    <PackageId>SolidToken.SpecFlow.DependencyInjection</PackageId>
     <Product>SpecFlow.DependencyInjection</Product>
+    <PackageId>SolidToken.SpecFlow.DependencyInjection</PackageId>
+    <RootNamespace>SolidToken.SpecFlow.DependencyInjection</RootNamespace>
+    <AssemblyName>SolidToken.SpecFlow.DependencyInjection.SpecFlowPlugin</AssemblyName>
     <Description>SpecFlow plugin that enables to use Microsoft.Extensions.DependencyInjection for resolving test dependencies.</Description>
     <Authors>Solid Token</Authors>
     <Company>Solid Token</Company>
@@ -10,13 +12,10 @@
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PackageProjectUrl>https://github.com/solidtoken/SpecFlow.DependencyInjection</PackageProjectUrl>
     <PackageIconUrl>https://avatars0.githubusercontent.com/u/413381</PackageIconUrl>
-    <PackageTags>specflow;plugin;microsoft;dependencyinjection;di</PackageTags>
+    <PackageTags>microsoft;dependencyinjection;di;specflow;plugin</PackageTags>
+    <PublishRepositoryUrl>true</PublishRepositoryUrl>
+    <DebugType>Embedded</DebugType>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-    <RepositoryType>git</RepositoryType>
-    <RepositoryUrl>https://github.com/solidtoken/SpecFlow.DependencyInjection.git</RepositoryUrl>
-    <RootNamespace>SolidToken.SpecFlow.DependencyInjection</RootNamespace>
-    <AssemblyName>SolidToken.SpecFlow.DependencyInjection.SpecFlowPlugin</AssemblyName>
-    <AllowedOutputExtensionsInPackageBuildOutputFolder>$(AllowedOutputExtensionsInPackageBuildOutputFolder);.pdb</AllowedOutputExtensionsInPackageBuildOutputFolder>
   </PropertyGroup>
   <ItemGroup>
     <None Include="build\**" Pack="True" PackagePath="build\" />


### PR DESCRIPTION
Temporary fix for SourceLink by embedding pdb in dll file.
We should provide Symbol Packages as part of #11.