### PR TITLE
Add tests for MSTest testing framework

### DIFF
--- a/SpecFlow.DependencyInjection.MSTest.Tests/DependencyInjectionPlugin.feature
+++ b/SpecFlow.DependencyInjection.MSTest.Tests/DependencyInjectionPlugin.feature
@@ -1,0 +1,8 @@
+﻿Feature: DependencyInjectionPlugin
+	As a developer I want to verify
+	that the plugin SolidToken.SpecFlow.DependencyInjection
+	allows me to use Microsoft.Extensions.DependencyInjection
+    inside the MSTest test framework
+
+Scenario: Test service injection
+	Then verify that TestService is correctly injected

--- a/SpecFlow.DependencyInjection.MSTest.Tests/DependencyInjectionPluginSteps.cs
+++ b/SpecFlow.DependencyInjection.MSTest.Tests/DependencyInjectionPluginSteps.cs
@@ -1,0 +1,35 @@
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+using TechTalk.SpecFlow;
+
+namespace SpecFlow.DependencyInjection.MSTest.Tests
+{
+    [Binding]
+    public class DependencyInjectionPluginSteps
+    {
+        private readonly ITestService testService;
+
+        public DependencyInjectionPluginSteps(ITestService testService)
+        {
+            this.testService = testService;
+        }
+
+        [Then(@"verify that TestService is correctly injected")]
+        public void ThenVerifyThatTestServiceIsCorrectlyInjected()
+        {
+            Assert.IsTrue(testService.Verify());
+        }
+    }
+
+    public interface ITestService
+    {
+        bool Verify();
+    }
+
+    public class TestService : ITestService
+    {
+        public bool Verify()
+        {
+            return true;
+        }
+    }
+}

--- a/SpecFlow.DependencyInjection.MSTest.Tests/SpecFlow.DependencyInjection.MSTest.Tests.csproj
+++ b/SpecFlow.DependencyInjection.MSTest.Tests/SpecFlow.DependencyInjection.MSTest.Tests.csproj
@@ -1,0 +1,22 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
+
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.2.0" />
+    <PackageReference Include="MSTest.TestAdapter" Version="2.0.0" />
+    <PackageReference Include="MSTest.TestFramework" Version="2.0.0" />
+    <PackageReference Include="coverlet.collector" Version="1.0.1" />
+    <PackageReference Include="SpecFlow.MsTest" Version="3.0.188" />
+    <PackageReference Include="SpecFlow.Tools.MsBuild.Generation" Version="3.0.188" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\SpecFlow.DependencyInjection\SpecFlow.DependencyInjection.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/SpecFlow.DependencyInjection.MSTest.Tests/TestDependencies.cs
+++ b/SpecFlow.DependencyInjection.MSTest.Tests/TestDependencies.cs
@@ -1,0 +1,30 @@
+﻿using System;
+using System.Linq;
+using Microsoft.Extensions.DependencyInjection;
+using SolidToken.SpecFlow.DependencyInjection;
+using TechTalk.SpecFlow;
+
+namespace SpecFlow.DependencyInjection.MSTest.Tests
+{
+    public static class TestDependencies
+    {
+        [ScenarioDependencies]
+        public static IServiceCollection CreateServices()
+        {
+            var services = new ServiceCollection();
+
+            // Add test dependencies
+            services.AddTransient<ITestService, TestService>();
+
+            // NOTE: This line is essential so that Microsoft.Extensions.DependencyInjection knows
+            // about the SpecFlow bindings (something normally BoDi does automatically).
+            // TODO: Find out if we can make this part of the Plugin
+            foreach (var type in typeof(TestDependencies).Assembly.GetTypes().Where(t => Attribute.IsDefined(t, typeof(BindingAttribute))))
+            {
+                services.AddSingleton(type);
+            }
+
+            return services;
+        }
+    }
+}

--- a/SpecFlow.DependencyInjection.sln
+++ b/SpecFlow.DependencyInjection.sln
@@ -20,6 +20,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "SpecFlow.DependencyInjectio
 		{CACF906A-7230-4E37-984C-739AB1620995} = {CACF906A-7230-4E37-984C-739AB1620995}
 	EndProjectSection
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SpecFlow.DependencyInjection.MSTest.Tests", "SpecFlow.DependencyInjection.MSTest.Tests\SpecFlow.DependencyInjection.MSTest.Tests.csproj", "{135867FC-F15C-4A32-AB0A-41F18CC320C8}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -34,6 +36,10 @@ Global
 		{927C1595-C4EB-4F05-91A7-D2B519B68076}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{927C1595-C4EB-4F05-91A7-D2B519B68076}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{927C1595-C4EB-4F05-91A7-D2B519B68076}.Release|Any CPU.Build.0 = Release|Any CPU
+		{135867FC-F15C-4A32-AB0A-41F18CC320C8}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{135867FC-F15C-4A32-AB0A-41F18CC320C8}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{135867FC-F15C-4A32-AB0A-41F18CC320C8}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{135867FC-F15C-4A32-AB0A-41F18CC320C8}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
Initial thought was that issue #24 was caused by using the MSTest testing framework. Although this was not the case, it does make sense to add tests based on MSTest testing framework.

Still needs cleanup (rename the existing XUnit test project), support for both 2.1 and 3.1 SDK and investigate whether it is possible to code share between MSTest and XUnit test project.