### PR TITLE
Fix DependencyInjectionPluginFramework in build.targets

### DIFF
--- a/SpecFlow.DependencyInjection.Tests/SpecFlow.DependencyInjection.Tests.csproj
+++ b/SpecFlow.DependencyInjection.Tests/SpecFlow.DependencyInjection.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp2.1;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>netcoreapp2.1;netcoreapp3.1;net472</TargetFrameworks>
     <IsPackable>false</IsPackable>
     <RootNamespace>SolidToken.SpecFlow.DependencyInjection.Tests</RootNamespace>
     <AssemblyName>SolidToken.SpecFlow.DependencyInjection.Tests</AssemblyName>
@@ -12,19 +12,14 @@
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1" PrivateAssets="All" />
-  </ItemGroup>
-
-  <!-- .NET Core 2.1 LTS (always use lowest applicable version) -->
-  <ItemGroup Condition=" '$(TargetFramework)' == 'netcoreapp2.1' ">
-    <PackageReference Include="SpecFlow.Tools.MsBuild.Generation" Version="3.0.188" />
-    <PackageReference Include="SpecFlow.xUnit" Version="3.0.188" />
+    <PackageReference Include="SpecFlow" Version="3.3.22-beta" />
+    <PackageReference Include="SpecFlow.Tools.MsBuild.Generation" Version="3.3.22-beta" />
+    <PackageReference Include="SpecFlow.xUnit" Version="3.3.22-beta" />
   </ItemGroup>
 
   <!-- .NET Core 3.1 LTS (always use latest applicable version) -->
   <ItemGroup Condition=" '$(TargetFramework)' == 'netcoreapp3.1' ">
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="3.1.1" />
-    <PackageReference Include="SpecFlow.Tools.MsBuild.Generation" Version="3.1.86" />
-    <PackageReference Include="SpecFlow.xUnit" Version="3.1.86" />
   </ItemGroup>
   
   <ItemGroup>

--- a/SpecFlow.DependencyInjection/SpecFlow.DependencyInjection.csproj
+++ b/SpecFlow.DependencyInjection/SpecFlow.DependencyInjection.csproj
@@ -18,9 +18,6 @@
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
   </PropertyGroup>
   <ItemGroup>
-    <None Include="build\**" Pack="True" PackagePath="build\" />
-  </ItemGroup>
-  <ItemGroup>
     <PackageReference Include="GitVersionTask" Version="5.1.3" PrivateAssets="All" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="2.1" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />

--- a/SpecFlow.DependencyInjection/build/SolidToken.SpecFlow.DependencyInjection.targets
+++ b/SpecFlow.DependencyInjection/build/SolidToken.SpecFlow.DependencyInjection.targets
@@ -1,7 +1,6 @@
 ﻿<Project ToolsVersion="12.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 	<PropertyGroup>
-		<_SpecFlow_DependencyInjectionPluginFramework Condition=" '$(TargetFrameworkIdentifier)' == '.NETCoreApp' ">netstandard2.0</_SpecFlow_DependencyInjectionPluginFramework>
-		<_SpecFlow_DependencyInjectionPluginFramework Condition=" '$(TargetFrameworkIdentifier)' == '.NETFramework' ">net45</_SpecFlow_DependencyInjectionPluginFramework>
+		<_SpecFlow_DependencyInjectionPluginFramework>netstandard2.0</_SpecFlow_DependencyInjectionPluginFramework>
 		<_SpecFlow_DependencyInjectionPluginPath>$(MSBuildThisFileDirectory)\..\lib\$(_SpecFlow_DependencyInjectionPluginFramework)\SolidToken.SpecFlow.DependencyInjection.SpecFlowPlugin.dll</_SpecFlow_DependencyInjectionPluginPath>
 	</PropertyGroup>
 </Project>


### PR DESCRIPTION
This PR fix the following issue occurring when using the plugin in a .NET framework project :
`error MSB3030: Could not copy the file "C:\Users\<username>\.nuget\packages\solidtoken.specflow.dependencyinjection\0.4.1\lib\net45\SolidToken.SpecFlow.DependencyInjection.SpecFlowPlugin.dll" because it was not found.`