### PR TITLE
Register IServiceProvider as a disposable instance instead of a factory.

### DIFF
--- a/SpecFlow.DependencyInjection.Tests/DisposeInstance.feature
+++ b/SpecFlow.DependencyInjection.Tests/DisposeInstance.feature
@@ -1,0 +1,14 @@
+﻿Feature: DisposeInstance
+
+The Dispose method of a binding exposing the IDisposable interface should be called
+
+Scenario Outline: Disposing
+The examples can be executed at random so we can't assume the order.
+	Then Dispose should have been called the right number of times
+
+    Examples: 
+    | times |
+    | 0     |
+    | 1     |
+    | 2     |
+

--- a/SpecFlow.DependencyInjection.Tests/DisposeInstanceSteps.cs
+++ b/SpecFlow.DependencyInjection.Tests/DisposeInstanceSteps.cs
@@ -1,0 +1,31 @@
+using System;
+using TechTalk.SpecFlow;
+using Xunit;
+
+namespace SolidToken.SpecFlow.DependencyInjection.Tests
+{
+    [Binding]
+    public class DisposeInstanceSteps : IDisposable
+    {
+        private static int DisposeCallCount { get; set; }
+        private static int InstanciationCount { get; set; }
+
+        public DisposeInstanceSteps()
+        {
+            InstanciationCount++;
+        }
+
+        [Then(@"Dispose should have been called the right number of times")]
+        public void ThenDisposeShouldHaveBeenCalledTimes()
+        {
+            var expected = InstanciationCount - 1;
+            Assert.Equal(expected, DisposeCallCount);
+        }
+
+        /// <inheritdoc />
+        public void Dispose()
+        {
+            DisposeCallCount++;
+        }
+    }
+}

--- a/SpecFlow.DependencyInjection/DependencyInjectionPlugin.cs
+++ b/SpecFlow.DependencyInjection/DependencyInjectionPlugin.cs
@@ -34,14 +34,12 @@ namespace SolidToken.SpecFlow.DependencyInjection
 
             runtimePluginEvents.CustomizeScenarioDependencies += (sender, args) =>
             {
-                args.ObjectContainer.RegisterFactoryAs<IServiceProvider>(() =>
-                {
-                    var serviceCollectionFinder = args.ObjectContainer.Resolve<IServiceCollectionFinder>();
-                    var createScenarioServiceCollection = serviceCollectionFinder.GetCreateScenarioServiceCollection();
-                    var services = createScenarioServiceCollection();
-                    RegisterSpecFlowDependencies(args.ObjectContainer, services);
-                    return services.BuildServiceProvider();
-                });
+                var serviceCollectionFinder = args.ObjectContainer.Resolve<IServiceCollectionFinder>();
+                var createScenarioServiceCollection = serviceCollectionFinder.GetCreateScenarioServiceCollection();
+                var services = createScenarioServiceCollection();
+                RegisterSpecFlowDependencies(args.ObjectContainer, services);
+                var provider = services.BuildServiceProvider();
+                args.ObjectContainer.RegisterInstanceAs(provider, typeof(IServiceProvider), dispose: true);
             };
         }
 


### PR DESCRIPTION
This PR resolve an issue concerning the disposal of instances handled by the `IServiceProvider`.
Seemingly due to a BoDi limitation, instances resolved from a factory are not disposed.

Now, when ServiceProvider is disposed it dispose successively the objects it instanciated.
Thus when declaring a binding as `IDisposable` the `Dispose` method is called at the end of test run.

Registrering as a factory is not needed because we have all the elements to instanciate the service provider.