### PR TITLE
Support SpecFlow v3.7.13

### DIFF
--- a/GitVersion.yml
+++ b/GitVersion.yml
@@ -9,4 +9,4 @@ branches:
     regex: ^dev$
   pull-request:
     tag: pr
-next-version: 3.6
+next-version: 3.7

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 SpecFlow plugin that enables to use Microsoft.Extensions.DependencyInjection for resolving test dependencies.
 
 Follows [SpecFlow versioning](https://specflow.org/blog/we-are-simplifying-our-specflow-and-net-version-support/) and currently targets:
-* [SpecFlow v3.6.23 or later](https://www.nuget.org/packages/SpecFlow/3.6.23)
+* [SpecFlow v3.7.13 or later](https://www.nuget.org/packages/SpecFlow/3.7.13)
 * [Microsoft.Extensions.DependencyInjection v5.0.1 or later](https://www.nuget.org/packages/Microsoft.Extensions.DependencyInjection/5.0.1)
 
 Based on [SpecFlow.Autofac](https://github.com/gasparnagy/SpecFlow.Autofac).

--- a/SpecFlow.DependencyInjection.Tests/SpecFlow.DependencyInjection.Tests.csproj
+++ b/SpecFlow.DependencyInjection.Tests/SpecFlow.DependencyInjection.Tests.csproj
@@ -20,8 +20,8 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="SpecFlow.xUnit" Version="3.6.23" />
-    <PackageReference Include="coverlet.collector" Version="3.0.1">
+    <PackageReference Include="SpecFlow.xUnit" Version="3.7.13" />
+    <PackageReference Include="coverlet.collector" Version="3.0.2">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/SpecFlow.DependencyInjection/SpecFlow.DependencyInjection.csproj
+++ b/SpecFlow.DependencyInjection/SpecFlow.DependencyInjection.csproj
@@ -38,6 +38,6 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="SpecFlow" Version="3.6.23" />
+    <PackageReference Include="SpecFlow" Version="3.7.13" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Fixes the breaking change presumably introduced by BoDi 1.5.

Contributor: @shaundodimead
Fixes: #37