### PR TITLE
Enable Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,9 @@
+# Please see the documentation for all configuration options:
+# https://help.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+
+version: 2
+updates:
+  - package-ecosystem: "nuget"
+    directory: "SpecFlow.DependencyInjection"
+    schedule:
+      interval: "daily"


### PR DESCRIPTION
Enable Dependabot for dependency checking on SpecFlow.DependencyInjection project.