### PR TITLE
real DI scoping

### DIFF
--- a/SpecFlow.DependencyInjection/DependencyInjectionTestObjectResolver.cs
+++ b/SpecFlow.DependencyInjection/DependencyInjectionTestObjectResolver.cs
@@ -1,15 +1,50 @@
 ﻿using System;
+using System.Collections.Concurrent;
+using System.Reflection;
 using BoDi;
+using Microsoft.Extensions.DependencyInjection;
 using TechTalk.SpecFlow.Infrastructure;
 
 namespace SolidToken.SpecFlow.DependencyInjection
 {
+    /* TODO
+       If SpecFlow will add an "IObjectContainer.IsRegistered(Type type)" method next to the existing "IsRegistered<T>()"
+       We can remove most of the code here!
+     */
     public class DependencyInjectionTestObjectResolver : ITestObjectResolver
     {
-        public object ResolveBindingInstance(Type bindingType, IObjectContainer scenarioContainer)
+        // Can remove if IsRegistered(Type type) exists
+        private static readonly ConcurrentDictionary<Type, MethodInfo> IsRegisteredMethodInfoCache =
+            new ConcurrentDictionary<Type, MethodInfo>();
+
+        // Can remove if IsRegistered(Type type) exists
+        private static readonly MethodInfo IsRegisteredMethodInfo = typeof(DependencyInjectionTestObjectResolver)
+            .GetMethod(nameof(IsRegistered), BindingFlags.Instance | BindingFlags.Public);
+
+        // Can remove if IsRegistered(Type type) exists
+        private static MethodInfo CreateGenericMethodInfo(Type t) => IsRegisteredMethodInfo.MakeGenericMethod(t);
+
+        public object ResolveBindingInstance(Type bindingType, IObjectContainer container)
         {
-            var provider = scenarioContainer.Resolve<IServiceProvider>();
-            return provider.GetService(bindingType);
+            // Can remove if IsRegistered(Type type) exists
+            var mi = IsRegisteredMethodInfoCache.GetOrAdd(bindingType, CreateGenericMethodInfo);
+            var registered = (bool) mi.Invoke(this, new object[] { container });
+            // var registered = container.IsRegistered(bindingType);
+            
+            return registered
+                ? container.Resolve(bindingType)
+                : container.Resolve<IServiceProvider>().GetRequiredService(bindingType);
+        }
+
+        public bool IsRegistered<T>(IObjectContainer container)
+        {
+            if (container.IsRegistered<T>())
+                return true;
+            
+            // IsRegistered is not recursive, it will only check the current container
+            if (container is ObjectContainer c && c.BaseContainer != null)
+                return IsRegistered<T>(c.BaseContainer);
+            return false;
         }
     }
 }

--- a/SpecFlow.DependencyInjection/IServiceCollectionFinder.cs
+++ b/SpecFlow.DependencyInjection/IServiceCollectionFinder.cs
@@ -5,6 +5,6 @@ namespace SolidToken.SpecFlow.DependencyInjection
 {
     public interface IServiceCollectionFinder
     {
-        Func<IServiceCollection> GetCreateScenarioServiceCollection();
+        (IServiceCollection, ScopeLevelType) GetServiceCollection();
     }
 }

--- a/SpecFlow.DependencyInjection/ScenarioDependenciesAttribute.cs
+++ b/SpecFlow.DependencyInjection/ScenarioDependenciesAttribute.cs
@@ -2,6 +2,18 @@
 
 namespace SolidToken.SpecFlow.DependencyInjection
 {
+    public enum ScopeLevelType
+    {
+        /// <summary>
+        /// Scoping is created for every scenario and it is destroyed once the scenario ends.
+        /// </summary>
+        Scenario,
+        /// <summary>
+        /// Scoping is created for Feature scenario and it is destroyed once the Feature ends.
+        /// </summary>
+        Feature
+    }
+    
     [AttributeUsage(AttributeTargets.Method)]
     public class ScenarioDependenciesAttribute : Attribute
     {
@@ -9,5 +21,9 @@ namespace SolidToken.SpecFlow.DependencyInjection
         /// Automatically register all SpecFlow bindings.
         /// </summary>
         public bool AutoRegisterBindings { get; set; } = true;
+        /// <summary>
+        /// Define when to create and destroy scope. 
+        /// </summary>
+        public ScopeLevelType ScopeLevel { get; set; } = ScopeLevelType.Scenario;
     }
 }


### PR DESCRIPTION
The current implementation is missing some of the goals of DI.

- It will create a new service container on every scenario (which might be slow)
  - It will build the service provider on every scenario  (which might be slow)
- The above is true for Features as well, i.e. Injections from Features will not be the same as in Scenario!!!
- It does not provide singleton option in the DI, as the DI is built every time
- It does not dispose the service providers, it's not possible since it's always the root provider
- It does not provide scope resolution. I.E Feature based scoping vs Scenario based scoping
- Because a new container was created on every scenario, a new instance of the binding class was created, not allowing property share via instance.

----

This PR fixes scoping for **Scenario** and add support for **Feature** scoping.

With **Scenario**:

- The service container is now created and built ONCE for the entire run
- Singleton are now possible for the entire run.
- Each **Scenario** is now a real `IServiceScope` which is also disposed once the **Scenario** is done

With **Feature**:

- The service container is now created and built ONCE for the entire run
- Singleton are now possible for the entire run.
- Each **Feature** is a `IServiceScope` which is also disposed once the **Feature** is done
- All Scenarios are injected using the same scope, i.e. they share injections
- **Feature** hooks can now get injections shared with the injection of the **Scenario**


To use **Feature** scoping

```
[ScenarioDependencies(ScopeLevel = ScopeLevelType.Feature)]
```

> The default is **Scenario** to ensure backward compatibility