### PR TITLE
Make ITestOutputHelper available

### DIFF
--- a/SpecFlow.DependencyInjection.Tests/ITestOutputHelper.feature
+++ b/SpecFlow.DependencyInjection.Tests/ITestOutputHelper.feature
@@ -1,0 +1,8 @@
+﻿Feature: ITestOutputHelper
+    Issue #75: ITestOutputHelper unavailable when using SpecFlow.xUnit
+    https://github.com/solidtoken/SpecFlow.DependencyInjection/issues/75
+
+Scenario: Assert ITestOutputHelper Is Available
+    The When part here is purely for displaying the message using ITestOutputHelper
+    When a message is output using ITestOutputHelper
+    Then verify that ITestOutputHelper is correctly injected

--- a/SpecFlow.DependencyInjection.Tests/ITestOutputHelperSteps.cs
+++ b/SpecFlow.DependencyInjection.Tests/ITestOutputHelperSteps.cs
@@ -1,0 +1,34 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using TechTalk.SpecFlow;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SolidToken.SpecFlow.DependencyInjection.Tests
+{
+    [Binding]
+    public class ITestOutputHelperSteps
+    {
+        private readonly ITestOutputHelper _output;
+
+        public ITestOutputHelperSteps(ITestOutputHelper output)
+        {
+            _output = output;
+        }
+
+        [When(@"a message is output using ITestOutputHelper")]
+        public void WhenAMessageIsOutputUsingITestOutputHelper()
+        {
+            _output.WriteLine("This is output from ITestOutputHelper");
+        }
+
+        [Then(@"verify that ITestOutputHelper is correctly injected")]
+        public void ThenVerifyThatITestOutputHelperIsCorrectlyInjected()
+        {
+            Assert.NotNull(_output);
+        }
+    }
+}

--- a/SpecFlow.DependencyInjection.Tests/TestDependencies.cs
+++ b/SpecFlow.DependencyInjection.Tests/TestDependencies.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Linq;
 using Microsoft.Extensions.DependencyInjection;
+using Xunit.Abstractions;
 
 namespace SolidToken.SpecFlow.DependencyInjection.Tests
 {


### PR DESCRIPTION
As a developer, I want to have `ITestOutputHelper` available in my tests so I can output logs.

This issue probably requires architectural design changes of the project, so not sure if this PR will be limited to _just_ the availability of `ITestOutputHelper` (probably want a solution which makes all parental dependencies available).