### PR TITLE
Enable publishing pre-release versions of package

### DIFF
--- a/GitVersion.yml
+++ b/GitVersion.yml
@@ -1,4 +1,4 @@
-mode: Mainline
+mode: ContinuousDelivery
 assembly-versioning-scheme: MajorMinorPatch
 assembly-file-versioning-format: '{Major}.{Minor}.{Patch}.{env:BUILD_BUILDID ?? 0}'
 assembly-informational-format: '{SemVer}+{ShortSha}'

--- a/GitVersion.yml
+++ b/GitVersion.yml
@@ -2,7 +2,7 @@ mode: ContinuousDeployment
 assembly-versioning-scheme: MajorMinorPatch
 assembly-file-versioning-format: '{Major}.{Minor}.{Patch}.{env:BUILD_BUILDID ?? 0}'
 assembly-informational-format: '{SemVer}+{ShortSha}'
-continuous-delivery-fallback-tag: rc
+continuous-delivery-fallback-tag: preview
 branches:
   main:
     regex: ^main$

--- a/GitVersion.yml
+++ b/GitVersion.yml
@@ -1,7 +1,8 @@
-mode: ContinuousDelivery
+mode: ContinuousDeployment
 assembly-versioning-scheme: MajorMinorPatch
 assembly-file-versioning-format: '{Major}.{Minor}.{Patch}.{env:BUILD_BUILDID ?? 0}'
 assembly-informational-format: '{SemVer}+{ShortSha}'
+continuous-delivery-fallback-tag: rc
 branches:
   main:
     regex: ^main$

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -23,7 +23,8 @@ trigger:
 - refs/tags/v*
 
 pool:
-  vmImage: 'ubuntu-18.04'
+  # Prefer `ubuntu-latest`, but `NuGetKeyVaultSignTool` won't work anymore on Linux (because of dotnet issue https://github.com/dotnet/runtime/issues/48794)
+  vmImage: 'windows-latest'
     
 stages:
 - stage: CI
@@ -89,7 +90,6 @@ stages:
       FullSemVer: $[stageDependencies.CI.Build.outputs['Version.GitVersion.FullSemVer']]
       NuGetVersion: $[stageDependencies.CI.Build.outputs['Version.GitVersion.NuGetVersion']]
       InformationalVersion: $[stageDependencies.CI.Build.outputs['Version.GitVersion.InformationalVersion']]
-      IsRelease: $[startsWith(variables['Build.SourceBranch'], 'refs/tags/')]
     steps:
     - task: DotNetCoreCLI@2
       displayName: 'Prepare'
@@ -136,6 +136,7 @@ stages:
         changeLogType: 'commitBased'
         isDraft: true
         isPreRelease: true
+
   # - job: Release
   #   condition: startsWith(variables['Build.SourceBranch'], 'refs/tags/')
   #   variables:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -117,16 +117,16 @@ stages:
           --azure-key-vault-client-id "$(azure-key-vault-client-id)" `
           --azure-key-vault-client-secret "$(azure-key-vault-client-secret)" `
           --azure-key-vault-certificate "$(azure-key-vault-certificate)"
-    # - task: NuGetCommand@2
-    #   displayName: 'Push'
-    #   inputs:
-    #     command: 'push'
-    #     packagesToPush: '$(Pipeline.Workspace)/*.nupkg'
-    #     nuGetFeedType: 'external'
-    #     publishFeedCredentials: '$(NuGetConnection)'
-    #     includeSymbols: true
+    - task: NuGetCommand@2
+      displayName: 'Push'
+      inputs:
+        command: 'push'
+        packagesToPush: '$(Pipeline.Workspace)/*.nupkg'
+        nuGetFeedType: 'external'
+        publishFeedCredentials: '$(NuGetConnection)'
+        includeSymbols: true
     - task: GitHubRelease@1
-      condition: startsWith(variables['Build.SourceBranch'], 'refs/heads/main')
+      condition: eq(variables['Build.SourceBranch'], 'refs/heads/main')
       displayName: 'Preview'
       inputs:
         gitHubConnection: '$(GitHubConnection)'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -83,13 +83,15 @@ stages:
 - stage: CD
   # condition: and(succeeded(), or(eq(variables['Build.SourceBranch'], 'refs/heads/main'), startsWith(variables['Build.SourceBranch'], 'refs/tags/')))
   jobs:
-  - job: Prerelease
+  - job: Release
     # condition: startsWith(variables['Build.SourceBranch'], 'refs/heads/main')
+    # condition: startsWith(variables['Build.SourceBranch'], 'refs/tags/')
     variables:
       SemVer: $[stageDependencies.CI.Build.outputs['Version.GitVersion.SemVer']]
       FullSemVer: $[stageDependencies.CI.Build.outputs['Version.GitVersion.FullSemVer']]
       NuGetVersion: $[stageDependencies.CI.Build.outputs['Version.GitVersion.NuGetVersion']]
       InformationalVersion: $[stageDependencies.CI.Build.outputs['Version.GitVersion.InformationalVersion']]
+      IsRelease: $[startsWith(variables['Build.SourceBranch'], 'refs/tags/')]
     steps:
     - task: DotNetCoreCLI@2
       displayName: 'Prepare'
@@ -115,7 +117,39 @@ stages:
           --azure-key-vault-client-id "$(azure-key-vault-client-id)" `
           --azure-key-vault-client-secret "$(azure-key-vault-client-secret)" `
           --azure-key-vault-certificate "$(azure-key-vault-certificate)"
+    # - task: NuGetCommand@2
+    #   displayName: 'Push'
+    #   inputs:
+    #     command: 'push'
+    #     packagesToPush: '$(Pipeline.Workspace)/*.nupkg'
+    #     nuGetFeedType: 'external'
+    #     publishFeedCredentials: '$(NuGetConnection)'
+    #     includeSymbols: true
     - task: GitHubRelease@1
+      condition: startsWith(variables['Build.SourceBranch'], 'refs/heads/main')
+      displayName: 'Preview'
+      inputs:
+        gitHubConnection: '$(GitHubConnection)'
+        repositoryName: '$(Build.Repository.Name)'
+        action: 'edit'
+        target: '$(Build.SourceVersion)'
+        tagSource: 'userSpecifiedTag'
+        tag: 'v$(SemVer)'
+        title: 'v$(FullSemVer)'
+        assets: '$(Pipeline.Workspace)/*'
+        releaseNotesSource: 'inline'
+        releaseNotesInline: |
+          $(NuGetDescription)
+          https://www.nuget.org/packages/$(NuGetPackageName)/$(NuGetVersion)
+
+          `$(informationalVersion)` (Preview)
+        changeLogCompareToRelease: 'lastFullRelease'
+        changeLogType: 'commitBased'
+        isDraft: true
+        # There is no way to set a boolean value except using a condition for the entire task
+        isPreRelease: true
+    - task: GitHubRelease@1
+      condition: startsWith(variables['Build.SourceBranch'], 'refs/tags/')
       displayName: 'Release'
       inputs:
         gitHubConnection: '$(GitHubConnection)'
@@ -135,67 +169,5 @@ stages:
         changeLogCompareToRelease: 'lastFullRelease'
         changeLogType: 'commitBased'
         isDraft: true
-        isPreRelease: true
-
-  # - job: Release
-  #   condition: startsWith(variables['Build.SourceBranch'], 'refs/tags/')
-  #   variables:
-  #     SemVer: $[stageDependencies.CI.Build.outputs['Version.GitVersion.SemVer']]
-  #     FullSemVer: $[stageDependencies.CI.Build.outputs['Version.GitVersion.FullSemVer']]
-  #     NuGetVersion: $[stageDependencies.CI.Build.outputs['Version.GitVersion.NuGetVersion']]
-  #     InformationalVersion: $[stageDependencies.CI.Build.outputs['Version.GitVersion.InformationalVersion']]
-  #     IsRelease: $[startsWith(variables['Build.SourceBranch'], 'refs/tags/')]
-  #   steps:
-  #   - task: DotNetCoreCLI@2
-  #     displayName: 'Prepare'
-  #     inputs:
-  #       command: 'custom'
-  #       custom: 'tool'
-  #       arguments: 'install --tool-path . NuGetKeyVaultSignTool'
-  #   - task: DownloadPipelineArtifact@2
-  #     displayName: 'Download'
-  #     inputs:
-  #       artifactName: '$(ProjectName)'
-  #   - task: PowerShell@2
-  #     displayName: 'Sign'
-  #     inputs:
-  #       targetType: 'inline'
-  #       script: |
-  #         .\NuGetKeyVaultSignTool sign $(Pipeline.Workspace)/*.nupkg `
-  #         --file-digest "sha256" `
-  #         --timestamp-rfc3161 "http://timestamp.sectigo.com" `
-  #         --timestamp-digest "sha256" `
-  #         --azure-key-vault-url "$(azure-key-vault-url)" `
-  #         --azure-key-vault-tenant-id "$(azure-key-vault-tenant-id)" `
-  #         --azure-key-vault-client-id "$(azure-key-vault-client-id)" `
-  #         --azure-key-vault-client-secret "$(azure-key-vault-client-secret)" `
-  #         --azure-key-vault-certificate "$(azure-key-vault-certificate)"
-  #   # - task: NuGetCommand@2
-  #   #   displayName: 'Push'
-  #   #   inputs:
-  #   #     command: 'push'
-  #   #     packagesToPush: '$(Pipeline.Workspace)/*.nupkg'
-  #   #     nuGetFeedType: 'external'
-  #   #     publishFeedCredentials: '$(NuGetConnection)'
-  #   #     includeSymbols: true
-  #   - task: GitHubRelease@1
-  #     displayName: 'Release'
-  #     inputs:
-  #       gitHubConnection: '$(GitHubConnection)'
-  #       repositoryName: '$(Build.Repository.Name)'
-  #       action: 'edit'
-  #       target: '$(Build.SourceVersion)'
-  #       tagSource: 'userSpecifiedTag'
-  #       tag: 'v$(SemVer)'
-  #       title: 'v$(FullSemVer)'
-  #       assets: '$(Pipeline.Workspace)/*'
-  #       releaseNotesSource: 'inline'
-  #       releaseNotesInline: |
-  #         $(NuGetDescription)
-  #         https://www.nuget.org/packages/$(NuGetPackageName)/$(NuGetVersion)
-
-  #         `$(informationalVersion)`
-  #       changeLogCompareToRelease: 'lastFullRelease'
-  #       changeLogType: 'commitBased'
-  #       isDraft: true
-  #       isPreRelease: false
+        # There is no way to set a boolean value except using a condition for the entire task
+        isPreRelease: false

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -81,7 +81,8 @@ stages:
 - stage: CD
   #condition: and(succeeded(), eq(variables['Build.SourceBranch'], 'refs/heads/main'))
   jobs:
-  - job: Release
+  - job: Prerelease
+    condition: startsWith(variables['Build.SourceBranch'], 'refs/heads/main')
     variables:
       SemVer: $[stageDependencies.CI.Build.outputs['Version.GitVersion.SemVer']]
       FullSemVer: $[stageDependencies.CI.Build.outputs['Version.GitVersion.FullSemVer']]
@@ -141,3 +142,66 @@ stages:
         changeLogType: 'commitBased'
         isDraft: true
         isPreRelease: true
+
+    
+  - job: Release
+    condition: startsWith(variables['Build.SourceBranch'], 'refs/tags/')
+    variables:
+      SemVer: $[stageDependencies.CI.Build.outputs['Version.GitVersion.SemVer']]
+      FullSemVer: $[stageDependencies.CI.Build.outputs['Version.GitVersion.FullSemVer']]
+      NuGetVersion: $[stageDependencies.CI.Build.outputs['Version.GitVersion.NuGetVersion']]
+      InformationalVersion: $[stageDependencies.CI.Build.outputs['Version.GitVersion.InformationalVersion']]
+    steps:
+    - task: DotNetCoreCLI@2
+      displayName: 'Prepare'
+      inputs:
+        command: 'custom'
+        custom: 'tool'
+        arguments: 'install --tool-path . NuGetKeyVaultSignTool'
+    - task: DownloadPipelineArtifact@2
+      displayName: 'Download'
+      inputs:
+        artifactName: '$(ProjectName)'
+    # - task: PowerShell@2
+    #   displayName: 'Sign'
+    #   inputs:
+    #     targetType: 'inline'
+    #     script: |
+    #       .\NuGetKeyVaultSignTool sign $(Pipeline.Workspace)/*.nupkg `
+    #       --file-digest "sha256" `
+    #       --timestamp-rfc3161 "http://timestamp.sectigo.com" `
+    #       --timestamp-digest "sha256" `
+    #       --azure-key-vault-url "$(azure-key-vault-url)" `
+    #       --azure-key-vault-tenant-id "$(azure-key-vault-tenant-id)" `
+    #       --azure-key-vault-client-id "$(azure-key-vault-client-id)" `
+    #       --azure-key-vault-client-secret "$(azure-key-vault-client-secret)" `
+    #       --azure-key-vault-certificate "$(azure-key-vault-certificate)"
+    # - task: NuGetCommand@2
+    #   displayName: 'Push'
+    #   inputs:
+    #     command: 'push'
+    #     packagesToPush: '$(Pipeline.Workspace)/*.nupkg'
+    #     nuGetFeedType: 'external'
+    #     publishFeedCredentials: '$(NuGetConnection)'
+    #     includeSymbols: true
+    - task: GitHubRelease@1
+      displayName: 'Release'
+      inputs:
+        gitHubConnection: '$(GitHubConnection)'
+        repositoryName: '$(Build.Repository.Name)'
+        action: 'edit'
+        target: '$(Build.SourceVersion)'
+        tagSource: 'userSpecifiedTag'
+        tag: 'v$(SemVer)'
+        title: 'v$(FullSemVer)'
+        assets: '$(Pipeline.Workspace)/*'
+        releaseNotesSource: 'inline'
+        releaseNotesInline: |
+          $(NuGetDescription)
+          https://www.nuget.org/packages/$(NuGetPackageName)/$(NuGetVersion)
+
+          `$(informationalVersion)`
+        changeLogCompareToRelease: 'lastFullRelease'
+        changeLogType: 'commitBased'
+        isDraft: true
+        isPreRelease: false

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -98,28 +98,28 @@ stages:
       displayName: 'Download'
       inputs:
         artifactName: '$(ProjectName)'
-    - task: PowerShell@2
-      displayName: 'Sign'
-      inputs:
-        targetType: 'inline'
-        script: |
-          .\NuGetKeyVaultSignTool sign $(Pipeline.Workspace)/*.nupkg `
-          --file-digest "sha256" `
-          --timestamp-rfc3161 "http://timestamp.sectigo.com" `
-          --timestamp-digest "sha256" `
-          --azure-key-vault-url "$(azure-key-vault-url)" `
-          --azure-key-vault-tenant-id "$(azure-key-vault-tenant-id)" `
-          --azure-key-vault-client-id "$(azure-key-vault-client-id)" `
-          --azure-key-vault-client-secret "$(azure-key-vault-client-secret)" `
-          --azure-key-vault-certificate "$(azure-key-vault-certificate)"
-    - task: NuGetCommand@2
-      displayName: 'Push'
-      inputs:
-        command: 'push'
-        packagesToPush: '$(Pipeline.Workspace)/*.nupkg'
-        nuGetFeedType: 'external'
-        publishFeedCredentials: '$(NuGetConnection)'
-        includeSymbols: true
+    # - task: PowerShell@2
+    #   displayName: 'Sign'
+    #   inputs:
+    #     targetType: 'inline'
+    #     script: |
+    #       .\NuGetKeyVaultSignTool sign $(Pipeline.Workspace)/*.nupkg `
+    #       --file-digest "sha256" `
+    #       --timestamp-rfc3161 "http://timestamp.sectigo.com" `
+    #       --timestamp-digest "sha256" `
+    #       --azure-key-vault-url "$(azure-key-vault-url)" `
+    #       --azure-key-vault-tenant-id "$(azure-key-vault-tenant-id)" `
+    #       --azure-key-vault-client-id "$(azure-key-vault-client-id)" `
+    #       --azure-key-vault-client-secret "$(azure-key-vault-client-secret)" `
+    #       --azure-key-vault-certificate "$(azure-key-vault-certificate)"
+    # - task: NuGetCommand@2
+    #   displayName: 'Push'
+    #   inputs:
+    #     command: 'push'
+    #     packagesToPush: '$(Pipeline.Workspace)/*.nupkg'
+    #     nuGetFeedType: 'external'
+    #     publishFeedCredentials: '$(NuGetConnection)'
+    #     includeSymbols: true
     - task: GitHubRelease@1
       displayName: 'Release'
       inputs:
@@ -139,4 +139,5 @@ stages:
           `$(informationalVersion)`
         changeLogCompareToRelease: 'lastFullRelease'
         changeLogType: 'commitBased'
-        isDraft: false
+        isDraft: true
+        isPreRelease: true

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -130,6 +130,11 @@ stages:
         script: |
           .\NuGetKeyVaultSignTool verify $(Pipeline.Workspace)/*.nupkg
     - task: NuGetCommand@2
+      displayName: 'Nuget Verify'
+      inputs:
+        command: 'custom'
+        arguments: 'verify -Signatures $(Pipeline.Workspace)/*.nupkg'
+    - task: NuGetCommand@2
       displayName: 'Push'
       inputs:
         command: 'push'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -108,7 +108,7 @@ stages:
       inputs:
         targetType: 'inline'
         script: |
-          .\NuGetKeyVaultSignTool sign $(Pipeline.Workspace)/*.nupkg `
+          .\NuGetKeyVaultSignTool sign $(Pipeline.Workspace)\*.nupkg `
           --file-digest "sha256" `
           --timestamp-rfc3161 "http://timestamp.sectigo.com" `
           --timestamp-digest "sha256" `

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -23,7 +23,7 @@ trigger:
 - refs/tags/v*
 
 pool:
-  vmImage: 'ubuntu-latest'
+  vmImage: 'windows-latest'
     
 stages:
 - stage: CI

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -82,11 +82,9 @@ stages:
         summaryFileLocation: '$(Agent.TempDirectory)/*/coverage.cobertura.xml'
 
 - stage: CD
-  # condition: and(succeeded(), or(eq(variables['Build.SourceBranch'], 'refs/heads/main'), startsWith(variables['Build.SourceBranch'], 'refs/tags/')))
+  condition: and(succeeded(), or(eq(variables['Build.SourceBranch'], 'refs/heads/main'), startsWith(variables['Build.SourceBranch'], 'refs/tags/')))
   jobs:
   - job: Release
-    # condition: startsWith(variables['Build.SourceBranch'], 'refs/heads/main')
-    # condition: startsWith(variables['Build.SourceBranch'], 'refs/tags/')
     variables:
       SemVer: $[stageDependencies.CI.Build.outputs['Version.GitVersion.SemVer']]
       FullSemVer: $[stageDependencies.CI.Build.outputs['Version.GitVersion.FullSemVer']]
@@ -127,7 +125,7 @@ stages:
         publishFeedCredentials: '$(NuGetConnection)'
         includeSymbols: true
     - task: GitHubRelease@1
-      # condition: eq(variables['Build.SourceBranch'], 'refs/heads/main')
+      condition: eq(variables['Build.SourceBranch'], 'refs/heads/main')
       displayName: 'Preview'
       inputs:
         gitHubConnection: '$(GitHubConnection)'
@@ -143,10 +141,10 @@ stages:
           $(NuGetDescription)
           https://www.nuget.org/packages/$(NuGetPackageName)/$(NuGetVersion)
 
-          `$(informationalVersion)` (Preview)
+          `$(informationalVersion)`
         changeLogCompareToRelease: 'lastFullRelease'
         changeLogType: 'commitBased'
-        isDraft: true
+        isDraft: false
         # There is no way to set a boolean value except using a condition for the entire task
         isPreRelease: true
     - task: GitHubRelease@1
@@ -169,6 +167,6 @@ stages:
           `$(informationalVersion)`
         changeLogCompareToRelease: 'lastFullRelease'
         changeLogType: 'commitBased'
-        isDraft: true
+        isDraft: false
         # There is no way to set a boolean value except using a condition for the entire task
         isPreRelease: false

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -79,7 +79,7 @@ stages:
         summaryFileLocation: '$(Agent.TempDirectory)/*/coverage.cobertura.xml'
 
 - stage: CD
-  condition: and(succeeded(), or(eq(variables['Build.SourceBranch'], 'refs/heads/main'), eq(variables['Build.SourceBranch'], 'refs/tags/')))
+  condition: and(succeeded(), or(eq(variables['Build.SourceBranch'], 'refs/heads/main'), startsWith(variables['Build.SourceBranch'], 'refs/tags/')))
   jobs:
   - job: Prerelease
     condition: startsWith(variables['Build.SourceBranch'], 'refs/heads/main')

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -93,6 +93,10 @@ stages:
       InformationalVersion: $[stageDependencies.CI.Build.outputs['Version.GitVersion.InformationalVersion']]
       IsRelease: $[startsWith(variables['Build.SourceBranch'], 'refs/tags/')]
     steps:
+    - task: UseDotNet@2
+      displayName: '.NET SDK 5.0 (until May 8, 2022)'
+      inputs:
+        version: 5.0.x
     - task: DotNetCoreCLI@2
       displayName: 'Prepare'
       inputs:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -123,6 +123,12 @@ stages:
           --azure-key-vault-client-id "$(azure-key-vault-client-id)" `
           --azure-key-vault-client-secret "$(azure-key-vault-client-secret)" `
           --azure-key-vault-certificate "$(azure-key-vault-certificate)"
+    - task: PowerShell@2
+      displayName: 'Verify'
+      inputs:
+        targetType: 'inline'
+        script: |
+          .\NuGetKeyVaultSignTool verify $(Pipeline.Workspace)/*.nupkg
     - task: NuGetCommand@2
       displayName: 'Push'
       inputs:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -79,48 +79,20 @@ stages:
         summaryFileLocation: '$(Agent.TempDirectory)/*/coverage.cobertura.xml'
 
 - stage: CD
-  #condition: and(succeeded(), eq(variables['Build.SourceBranch'], 'refs/heads/main'))
+  condition: and(succeeded(), or(eq(variables['Build.SourceBranch'], 'refs/heads/main'), eq(variables['Build.SourceBranch'], 'refs/tags/')))
   jobs:
   - job: Prerelease
-    #condition: startsWith(variables['Build.SourceBranch'], 'refs/heads/main')
+    condition: startsWith(variables['Build.SourceBranch'], 'refs/heads/main')
     variables:
       SemVer: $[stageDependencies.CI.Build.outputs['Version.GitVersion.SemVer']]
       FullSemVer: $[stageDependencies.CI.Build.outputs['Version.GitVersion.FullSemVer']]
       NuGetVersion: $[stageDependencies.CI.Build.outputs['Version.GitVersion.NuGetVersion']]
       InformationalVersion: $[stageDependencies.CI.Build.outputs['Version.GitVersion.InformationalVersion']]
     steps:
-    # - task: DotNetCoreCLI@2
-    #   displayName: 'Prepare'
-    #   inputs:
-    #     command: 'custom'
-    #     custom: 'tool'
-    #     arguments: 'install --tool-path . NuGetKeyVaultSignTool'
     - task: DownloadPipelineArtifact@2
       displayName: 'Download'
       inputs:
         artifactName: '$(ProjectName)'
-    # - task: PowerShell@2
-    #   displayName: 'Sign'
-    #   inputs:
-    #     targetType: 'inline'
-    #     script: |
-    #       .\NuGetKeyVaultSignTool sign $(Pipeline.Workspace)/*.nupkg `
-    #       --file-digest "sha256" `
-    #       --timestamp-rfc3161 "http://timestamp.sectigo.com" `
-    #       --timestamp-digest "sha256" `
-    #       --azure-key-vault-url "$(azure-key-vault-url)" `
-    #       --azure-key-vault-tenant-id "$(azure-key-vault-tenant-id)" `
-    #       --azure-key-vault-client-id "$(azure-key-vault-client-id)" `
-    #       --azure-key-vault-client-secret "$(azure-key-vault-client-secret)" `
-    #       --azure-key-vault-certificate "$(azure-key-vault-certificate)"
-    # - task: NuGetCommand@2
-    #   displayName: 'Push'
-    #   inputs:
-    #     command: 'push'
-    #     packagesToPush: '$(Pipeline.Workspace)/*.nupkg'
-    #     nuGetFeedType: 'external'
-    #     publishFeedCredentials: '$(NuGetConnection)'
-    #     includeSymbols: true
     - task: GitHubRelease@1
       displayName: 'Release'
       inputs:
@@ -142,8 +114,6 @@ stages:
         changeLogType: 'commitBased'
         isDraft: true
         isPreRelease: true
-
-    
   - job: Release
     condition: startsWith(variables['Build.SourceBranch'], 'refs/tags/')
     variables:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -80,10 +80,10 @@ stages:
         summaryFileLocation: '$(Agent.TempDirectory)/*/coverage.cobertura.xml'
 
 - stage: CD
-  condition: and(succeeded(), or(eq(variables['Build.SourceBranch'], 'refs/heads/main'), startsWith(variables['Build.SourceBranch'], 'refs/tags/')))
+  # condition: and(succeeded(), or(eq(variables['Build.SourceBranch'], 'refs/heads/main'), startsWith(variables['Build.SourceBranch'], 'refs/tags/')))
   jobs:
   - job: Prerelease
-    condition: startsWith(variables['Build.SourceBranch'], 'refs/heads/main')
+    # condition: startsWith(variables['Build.SourceBranch'], 'refs/heads/main')
     variables:
       SemVer: $[stageDependencies.CI.Build.outputs['Version.GitVersion.SemVer']]
       FullSemVer: $[stageDependencies.CI.Build.outputs['Version.GitVersion.FullSemVer']]
@@ -136,65 +136,65 @@ stages:
         changeLogType: 'commitBased'
         isDraft: true
         isPreRelease: true
-  - job: Release
-    condition: startsWith(variables['Build.SourceBranch'], 'refs/tags/')
-    variables:
-      SemVer: $[stageDependencies.CI.Build.outputs['Version.GitVersion.SemVer']]
-      FullSemVer: $[stageDependencies.CI.Build.outputs['Version.GitVersion.FullSemVer']]
-      NuGetVersion: $[stageDependencies.CI.Build.outputs['Version.GitVersion.NuGetVersion']]
-      InformationalVersion: $[stageDependencies.CI.Build.outputs['Version.GitVersion.InformationalVersion']]
-      IsRelease: $[startsWith(variables['Build.SourceBranch'], 'refs/tags/')]
-    steps:
-    - task: DotNetCoreCLI@2
-      displayName: 'Prepare'
-      inputs:
-        command: 'custom'
-        custom: 'tool'
-        arguments: 'install --tool-path . NuGetKeyVaultSignTool'
-    - task: DownloadPipelineArtifact@2
-      displayName: 'Download'
-      inputs:
-        artifactName: '$(ProjectName)'
-    - task: PowerShell@2
-      displayName: 'Sign'
-      inputs:
-        targetType: 'inline'
-        script: |
-          .\NuGetKeyVaultSignTool sign $(Pipeline.Workspace)/*.nupkg `
-          --file-digest "sha256" `
-          --timestamp-rfc3161 "http://timestamp.sectigo.com" `
-          --timestamp-digest "sha256" `
-          --azure-key-vault-url "$(azure-key-vault-url)" `
-          --azure-key-vault-tenant-id "$(azure-key-vault-tenant-id)" `
-          --azure-key-vault-client-id "$(azure-key-vault-client-id)" `
-          --azure-key-vault-client-secret "$(azure-key-vault-client-secret)" `
-          --azure-key-vault-certificate "$(azure-key-vault-certificate)"
-    # - task: NuGetCommand@2
-    #   displayName: 'Push'
-    #   inputs:
-    #     command: 'push'
-    #     packagesToPush: '$(Pipeline.Workspace)/*.nupkg'
-    #     nuGetFeedType: 'external'
-    #     publishFeedCredentials: '$(NuGetConnection)'
-    #     includeSymbols: true
-    - task: GitHubRelease@1
-      displayName: 'Release'
-      inputs:
-        gitHubConnection: '$(GitHubConnection)'
-        repositoryName: '$(Build.Repository.Name)'
-        action: 'edit'
-        target: '$(Build.SourceVersion)'
-        tagSource: 'userSpecifiedTag'
-        tag: 'v$(SemVer)'
-        title: 'v$(FullSemVer)'
-        assets: '$(Pipeline.Workspace)/*'
-        releaseNotesSource: 'inline'
-        releaseNotesInline: |
-          $(NuGetDescription)
-          https://www.nuget.org/packages/$(NuGetPackageName)/$(NuGetVersion)
+  # - job: Release
+  #   condition: startsWith(variables['Build.SourceBranch'], 'refs/tags/')
+  #   variables:
+  #     SemVer: $[stageDependencies.CI.Build.outputs['Version.GitVersion.SemVer']]
+  #     FullSemVer: $[stageDependencies.CI.Build.outputs['Version.GitVersion.FullSemVer']]
+  #     NuGetVersion: $[stageDependencies.CI.Build.outputs['Version.GitVersion.NuGetVersion']]
+  #     InformationalVersion: $[stageDependencies.CI.Build.outputs['Version.GitVersion.InformationalVersion']]
+  #     IsRelease: $[startsWith(variables['Build.SourceBranch'], 'refs/tags/')]
+  #   steps:
+  #   - task: DotNetCoreCLI@2
+  #     displayName: 'Prepare'
+  #     inputs:
+  #       command: 'custom'
+  #       custom: 'tool'
+  #       arguments: 'install --tool-path . NuGetKeyVaultSignTool'
+  #   - task: DownloadPipelineArtifact@2
+  #     displayName: 'Download'
+  #     inputs:
+  #       artifactName: '$(ProjectName)'
+  #   - task: PowerShell@2
+  #     displayName: 'Sign'
+  #     inputs:
+  #       targetType: 'inline'
+  #       script: |
+  #         .\NuGetKeyVaultSignTool sign $(Pipeline.Workspace)/*.nupkg `
+  #         --file-digest "sha256" `
+  #         --timestamp-rfc3161 "http://timestamp.sectigo.com" `
+  #         --timestamp-digest "sha256" `
+  #         --azure-key-vault-url "$(azure-key-vault-url)" `
+  #         --azure-key-vault-tenant-id "$(azure-key-vault-tenant-id)" `
+  #         --azure-key-vault-client-id "$(azure-key-vault-client-id)" `
+  #         --azure-key-vault-client-secret "$(azure-key-vault-client-secret)" `
+  #         --azure-key-vault-certificate "$(azure-key-vault-certificate)"
+  #   # - task: NuGetCommand@2
+  #   #   displayName: 'Push'
+  #   #   inputs:
+  #   #     command: 'push'
+  #   #     packagesToPush: '$(Pipeline.Workspace)/*.nupkg'
+  #   #     nuGetFeedType: 'external'
+  #   #     publishFeedCredentials: '$(NuGetConnection)'
+  #   #     includeSymbols: true
+  #   - task: GitHubRelease@1
+  #     displayName: 'Release'
+  #     inputs:
+  #       gitHubConnection: '$(GitHubConnection)'
+  #       repositoryName: '$(Build.Repository.Name)'
+  #       action: 'edit'
+  #       target: '$(Build.SourceVersion)'
+  #       tagSource: 'userSpecifiedTag'
+  #       tag: 'v$(SemVer)'
+  #       title: 'v$(FullSemVer)'
+  #       assets: '$(Pipeline.Workspace)/*'
+  #       releaseNotesSource: 'inline'
+  #       releaseNotesInline: |
+  #         $(NuGetDescription)
+  #         https://www.nuget.org/packages/$(NuGetPackageName)/$(NuGetVersion)
 
-          `$(informationalVersion)`
-        changeLogCompareToRelease: 'lastFullRelease'
-        changeLogType: 'commitBased'
-        isDraft: true
-        isPreRelease: false
+  #         `$(informationalVersion)`
+  #       changeLogCompareToRelease: 'lastFullRelease'
+  #       changeLogType: 'commitBased'
+  #       isDraft: true
+  #       isPreRelease: false

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -94,9 +94,9 @@ stages:
       IsRelease: $[startsWith(variables['Build.SourceBranch'], 'refs/tags/')]
     steps:
     - task: UseDotNet@2
-      displayName: '.NET SDK 5.0 (until May 8, 2022)'
+      displayName: '.NET SDK 3.1 (until December 3, 2022)'
       inputs:
-        version: 5.0.x
+        version: 3.1.x      
     - task: DotNetCoreCLI@2
       displayName: 'Prepare'
       inputs:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -23,7 +23,7 @@ trigger:
 - refs/tags/v*
 
 pool:
-  vmImage: 'windows-latest'
+  vmImage: 'ubuntu-18.04'
     
 stages:
 - stage: CI

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -20,6 +20,7 @@ variables:
 
 trigger:
 - main
+- refs/tags/v*
 
 pool:
   vmImage: 'ubuntu-latest'
@@ -88,11 +89,32 @@ stages:
       FullSemVer: $[stageDependencies.CI.Build.outputs['Version.GitVersion.FullSemVer']]
       NuGetVersion: $[stageDependencies.CI.Build.outputs['Version.GitVersion.NuGetVersion']]
       InformationalVersion: $[stageDependencies.CI.Build.outputs['Version.GitVersion.InformationalVersion']]
+      IsRelease: $[startsWith(variables['Build.SourceBranch'], 'refs/tags/')]
     steps:
+    - task: DotNetCoreCLI@2
+      displayName: 'Prepare'
+      inputs:
+        command: 'custom'
+        custom: 'tool'
+        arguments: 'install --tool-path . NuGetKeyVaultSignTool'
     - task: DownloadPipelineArtifact@2
       displayName: 'Download'
       inputs:
         artifactName: '$(ProjectName)'
+    - task: PowerShell@2
+      displayName: 'Sign'
+      inputs:
+        targetType: 'inline'
+        script: |
+          .\NuGetKeyVaultSignTool sign $(Pipeline.Workspace)/*.nupkg `
+          --file-digest "sha256" `
+          --timestamp-rfc3161 "http://timestamp.sectigo.com" `
+          --timestamp-digest "sha256" `
+          --azure-key-vault-url "$(azure-key-vault-url)" `
+          --azure-key-vault-tenant-id "$(azure-key-vault-tenant-id)" `
+          --azure-key-vault-client-id "$(azure-key-vault-client-id)" `
+          --azure-key-vault-client-secret "$(azure-key-vault-client-secret)" `
+          --azure-key-vault-certificate "$(azure-key-vault-certificate)"
     - task: GitHubRelease@1
       displayName: 'Release'
       inputs:
@@ -121,6 +143,7 @@ stages:
       FullSemVer: $[stageDependencies.CI.Build.outputs['Version.GitVersion.FullSemVer']]
       NuGetVersion: $[stageDependencies.CI.Build.outputs['Version.GitVersion.NuGetVersion']]
       InformationalVersion: $[stageDependencies.CI.Build.outputs['Version.GitVersion.InformationalVersion']]
+      IsRelease: $[startsWith(variables['Build.SourceBranch'], 'refs/tags/')]
     steps:
     - task: DotNetCoreCLI@2
       displayName: 'Prepare'
@@ -132,20 +155,20 @@ stages:
       displayName: 'Download'
       inputs:
         artifactName: '$(ProjectName)'
-    # - task: PowerShell@2
-    #   displayName: 'Sign'
-    #   inputs:
-    #     targetType: 'inline'
-    #     script: |
-    #       .\NuGetKeyVaultSignTool sign $(Pipeline.Workspace)/*.nupkg `
-    #       --file-digest "sha256" `
-    #       --timestamp-rfc3161 "http://timestamp.sectigo.com" `
-    #       --timestamp-digest "sha256" `
-    #       --azure-key-vault-url "$(azure-key-vault-url)" `
-    #       --azure-key-vault-tenant-id "$(azure-key-vault-tenant-id)" `
-    #       --azure-key-vault-client-id "$(azure-key-vault-client-id)" `
-    #       --azure-key-vault-client-secret "$(azure-key-vault-client-secret)" `
-    #       --azure-key-vault-certificate "$(azure-key-vault-certificate)"
+    - task: PowerShell@2
+      displayName: 'Sign'
+      inputs:
+        targetType: 'inline'
+        script: |
+          .\NuGetKeyVaultSignTool sign $(Pipeline.Workspace)/*.nupkg `
+          --file-digest "sha256" `
+          --timestamp-rfc3161 "http://timestamp.sectigo.com" `
+          --timestamp-digest "sha256" `
+          --azure-key-vault-url "$(azure-key-vault-url)" `
+          --azure-key-vault-tenant-id "$(azure-key-vault-tenant-id)" `
+          --azure-key-vault-client-id "$(azure-key-vault-client-id)" `
+          --azure-key-vault-client-secret "$(azure-key-vault-client-secret)" `
+          --azure-key-vault-certificate "$(azure-key-vault-certificate)"
     # - task: NuGetCommand@2
     #   displayName: 'Push'
     #   inputs:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -24,6 +24,7 @@ trigger:
 
 pool:
   # Prefer `ubuntu-latest`, but `NuGetKeyVaultSignTool` won't work anymore on Linux (because of dotnet issue https://github.com/dotnet/runtime/issues/48794)
+  # Also make sure that the proper / or \ is used (according to OS) in the 'Sign' task below
   vmImage: 'windows-latest'
     
 stages:
@@ -117,14 +118,14 @@ stages:
           --azure-key-vault-client-id "$(azure-key-vault-client-id)" `
           --azure-key-vault-client-secret "$(azure-key-vault-client-secret)" `
           --azure-key-vault-certificate "$(azure-key-vault-certificate)"
-    # - task: NuGetCommand@2
-    #   displayName: 'Push'
-    #   inputs:
-    #     command: 'push'
-    #     packagesToPush: '$(Pipeline.Workspace)/*.nupkg'
-    #     nuGetFeedType: 'external'
-    #     publishFeedCredentials: '$(NuGetConnection)'
-    #     includeSymbols: true
+    - task: NuGetCommand@2
+      displayName: 'Push'
+      inputs:
+        command: 'push'
+        packagesToPush: '$(Pipeline.Workspace)/*.nupkg'
+        nuGetFeedType: 'external'
+        publishFeedCredentials: '$(NuGetConnection)'
+        includeSymbols: true
     - task: GitHubRelease@1
       # condition: eq(variables['Build.SourceBranch'], 'refs/heads/main')
       displayName: 'Preview'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -82,19 +82,19 @@ stages:
   #condition: and(succeeded(), eq(variables['Build.SourceBranch'], 'refs/heads/main'))
   jobs:
   - job: Prerelease
-    condition: startsWith(variables['Build.SourceBranch'], 'refs/heads/main')
+    #condition: startsWith(variables['Build.SourceBranch'], 'refs/heads/main')
     variables:
       SemVer: $[stageDependencies.CI.Build.outputs['Version.GitVersion.SemVer']]
       FullSemVer: $[stageDependencies.CI.Build.outputs['Version.GitVersion.FullSemVer']]
       NuGetVersion: $[stageDependencies.CI.Build.outputs['Version.GitVersion.NuGetVersion']]
       InformationalVersion: $[stageDependencies.CI.Build.outputs['Version.GitVersion.InformationalVersion']]
     steps:
-    - task: DotNetCoreCLI@2
-      displayName: 'Prepare'
-      inputs:
-        command: 'custom'
-        custom: 'tool'
-        arguments: 'install --tool-path . NuGetKeyVaultSignTool'
+    # - task: DotNetCoreCLI@2
+    #   displayName: 'Prepare'
+    #   inputs:
+    #     command: 'custom'
+    #     custom: 'tool'
+    #     arguments: 'install --tool-path . NuGetKeyVaultSignTool'
     - task: DownloadPipelineArtifact@2
       displayName: 'Download'
       inputs:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -104,12 +104,6 @@ stages:
       inputs:
         artifactName: '$(ProjectName)'
     - task: PowerShell@2
-      displayName: 'Version'
-      inputs:
-        targetType: 'inline'
-        script: |
-          .\NuGetKeyVaultSignTool --version
-    - task: PowerShell@2
       displayName: 'Sign'
       inputs:
         targetType: 'inline'
@@ -123,27 +117,16 @@ stages:
           --azure-key-vault-client-id "$(azure-key-vault-client-id)" `
           --azure-key-vault-client-secret "$(azure-key-vault-client-secret)" `
           --azure-key-vault-certificate "$(azure-key-vault-certificate)"
-    - task: PowerShell@2
-      displayName: 'Verify'
-      inputs:
-        targetType: 'inline'
-        script: |
-          .\NuGetKeyVaultSignTool verify $(Pipeline.Workspace)/*.nupkg
-    - task: NuGetCommand@2
-      displayName: 'Nuget Verify'
-      inputs:
-        command: 'custom'
-        arguments: 'verify -Signatures $(Pipeline.Workspace)/*.nupkg'
-    - task: NuGetCommand@2
-      displayName: 'Push'
-      inputs:
-        command: 'push'
-        packagesToPush: '$(Pipeline.Workspace)/*.nupkg'
-        nuGetFeedType: 'external'
-        publishFeedCredentials: '$(NuGetConnection)'
-        includeSymbols: true
+    # - task: NuGetCommand@2
+    #   displayName: 'Push'
+    #   inputs:
+    #     command: 'push'
+    #     packagesToPush: '$(Pipeline.Workspace)/*.nupkg'
+    #     nuGetFeedType: 'external'
+    #     publishFeedCredentials: '$(NuGetConnection)'
+    #     includeSymbols: true
     - task: GitHubRelease@1
-      condition: eq(variables['Build.SourceBranch'], 'refs/heads/main')
+      # condition: eq(variables['Build.SourceBranch'], 'refs/heads/main')
       displayName: 'Preview'
       inputs:
         gitHubConnection: '$(GitHubConnection)'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -79,7 +79,7 @@ stages:
         summaryFileLocation: '$(Agent.TempDirectory)/*/coverage.cobertura.xml'
 
 - stage: CD
-  condition: and(succeeded(), eq(variables['Build.SourceBranch'], 'refs/heads/main'))
+  #condition: and(succeeded(), eq(variables['Build.SourceBranch'], 'refs/heads/main'))
   jobs:
   - job: Release
     variables:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -93,10 +93,6 @@ stages:
       InformationalVersion: $[stageDependencies.CI.Build.outputs['Version.GitVersion.InformationalVersion']]
       IsRelease: $[startsWith(variables['Build.SourceBranch'], 'refs/tags/')]
     steps:
-    - task: UseDotNet@2
-      displayName: '.NET SDK 3.1 (until December 3, 2022)'
-      inputs:
-        version: 3.1.x      
     - task: DotNetCoreCLI@2
       displayName: 'Prepare'
       inputs:
@@ -107,6 +103,12 @@ stages:
       displayName: 'Download'
       inputs:
         artifactName: '$(ProjectName)'
+    - task: PowerShell@2
+      displayName: 'Version'
+      inputs:
+        targetType: 'inline'
+        script: |
+          .\NuGetKeyVaultSignTool --version
     - task: PowerShell@2
       displayName: 'Sign'
       inputs:


### PR DESCRIPTION
Changes GitVersion mode to `ContinuousDeployment`.

`main` is build, signed and pushed to NuGet as pre-release version.
`tags` is build, signed and pushed to NuGet as release version (with the tag).

Tagging the version is a manual step.

Fixes: #81 