### PR TITLE
Patch GitVersion inconsistency

### DIFF
--- a/GitVersion.yml
+++ b/GitVersion.yml
@@ -6,3 +6,5 @@ continuous-delivery-fallback-tag: preview
 branches:
   pull-request:
     tag: pr
+ignore:
+  commits-before: 2022-05-22T12:52:14+0200


### PR DESCRIPTION
Probably related to (another one of) GitVersion's backwards incompatibilities.