### PR TITLE
Ensure alpha tag for feature branches

### DIFF
--- a/GitVersion.yml
+++ b/GitVersion.yml
@@ -4,6 +4,8 @@ assembly-file-versioning-format: '{Major}.{Minor}.{Patch}.{env:BUILD_BUILDID ?? 
 assembly-informational-format: '{SemVer}+{ShortSha}'
 continuous-delivery-fallback-tag: preview
 branches:
+  feature:
+    tag: alpha.{BranchName}
   pull-request:
     tag: pr
 ignore:


### PR DESCRIPTION
This makes sure that feature branches are never selected before preview branches by prefixing them with alpha.