### PR TITLE
Revert change to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,8 +8,8 @@
 SpecFlow plugin that enables to use Microsoft.Extensions.DependencyInjection for resolving test dependencies.
 
 Currently supports:
-* [SpecFlow v4](https://www.nuget.org/packages/SpecFlow/4) or above
-* [Microsoft.Extensions.DependencyInjection v6.0.0](https://www.nuget.org/packages/Microsoft.Extensions.DependencyInjection/6.0.0) or above
+* [SpecFlow v3.9.8](https://www.nuget.org/packages/SpecFlow/3.9.8) or above
+* [Microsoft.Extensions.DependencyInjection v3.1.0](https://www.nuget.org/packages/Microsoft.Extensions.DependencyInjection/3.1.0) or above
 
 Based on [SpecFlow.Autofac](https://github.com/gasparnagy/SpecFlow.Autofac).
 Listed on [Available Plugins for SpecFlow](https://specflow.org/documentation/Available-Plugins/).


### PR DESCRIPTION
This is the problem with developing on main without immediately releasing the changes; any textual changes (e.g. the supported versions in README) are effectuaded immediately, but the binaries don't have to be released yet -- so there's not a single unit of deployment.