### PR TITLE
Support SpecFlow v4

### DIFF
--- a/GitVersion.yml
+++ b/GitVersion.yml
@@ -4,9 +4,7 @@ assembly-file-versioning-format: '{Major}.{Minor}.{Patch}.{env:BUILD_BUILDID ?? 
 assembly-informational-format: '{SemVer}+{ShortSha}'
 continuous-delivery-fallback-tag: preview
 branches:
-  main:
-    regex: ^main$
-  develop:
-    regex: ^dev$
+  feature:
+    tag: alpha.{BranchName}
   pull-request:
     tag: pr

--- a/README.md
+++ b/README.md
@@ -7,9 +7,9 @@
 
 SpecFlow plugin that enables to use Microsoft.Extensions.DependencyInjection for resolving test dependencies.
 
-Currently supports:
-* [SpecFlow v3.9.8](https://www.nuget.org/packages/SpecFlow/3.9.8) or above
-* [Microsoft.Extensions.DependencyInjection v3.1.0](https://www.nuget.org/packages/Microsoft.Extensions.DependencyInjection/3.1.0) or above
+Currently supports *(in preview)*:
+* [SpecFlow v4](https://www.nuget.org/packages/SpecFlow/4) or above
+* [Microsoft.Extensions.DependencyInjection v6.0.0](https://www.nuget.org/packages/Microsoft.Extensions.DependencyInjection/6.0.0) or above
 
 Based on [SpecFlow.Autofac](https://github.com/gasparnagy/SpecFlow.Autofac).
 Listed on [Available Plugins for SpecFlow](https://specflow.org/documentation/Available-Plugins/).

--- a/SpecFlow.DependencyInjection.Tests/SpecFlow.DependencyInjection.Tests.csproj
+++ b/SpecFlow.DependencyInjection.Tests/SpecFlow.DependencyInjection.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net461;netcoreapp3.1;net5.0;net6.0</TargetFrameworks>
+    <TargetFrameworks>net462;net6.0</TargetFrameworks>
     <IsPackable>false</IsPackable>
     <Product>SpecFlow.DependencyInjection</Product>
     <RootNamespace>SolidToken.SpecFlow.DependencyInjection.Tests</RootNamespace>
@@ -9,27 +9,27 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="GitVersion.MsBuild" Version="5.7.0">
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-      <PrivateAssets>all</PrivateAssets>
-    </PackageReference>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0" />
+    <PackageReference Include="SpecFlow" Version="4.*-*" />
+    <PackageReference Include="SpecFlow.xUnit" Version="4.*-*" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.0" />
     <PackageReference Include="Microsoft.TestPlatform.ObjectModel" Version="16.8.0" Condition="$(TargetFramework.StartsWith('net4')) AND '$(OS)' == 'Unix'" />
-    <PackageReference Include="SpecFlow" Version="3.9.8" />
-    <PackageReference Include="xunit" Version="2.4.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
+    <PackageReference Include="xunit" Version="2.4.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="SpecFlow.xUnit" Version="3.9.8" />
-    <PackageReference Include="coverlet.collector" Version="3.1.0">
+    <PackageReference Include="coverlet.collector" Version="3.2.0">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="GitVersion.MsBuild" Version="5.11.1">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFrameworkIdentifier)' == '.NETFramework' ">
-    <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.2">
+    <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.3">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/SpecFlow.DependencyInjection/SpecFlow.DependencyInjection.csproj
+++ b/SpecFlow.DependencyInjection/SpecFlow.DependencyInjection.csproj
@@ -31,15 +31,15 @@
     <None Include="build/*" Pack="true" Visible="true" PackagePath="build/" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="GitVersion.MsBuild" Version="5.7.0">
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-      <PrivateAssets>all</PrivateAssets>
-    </PackageReference>
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="3.1.0" />
+    <PackageReference Include="SpecFlow" Version="4.*-*" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="6.0.0" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="SpecFlow" Version="3.9.8" />
+    <PackageReference Include="GitVersion.MsBuild" Version="5.11.1">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
   </ItemGroup>
 </Project>

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -33,21 +33,13 @@ stages:
   - job: Build
     steps:
     - task: UseDotNet@2
-      displayName: '.NET SDK 3.1 (until December 3, 2022)'
-      inputs:
-        version: 3.1.x      
-    - task: UseDotNet@2
-      displayName: '.NET SDK 5.0 (until May 8, 2022)'
-      inputs:
-        version: 5.0.x
-    - task: UseDotNet@2
       displayName: '.NET SDK 6.0 (until November 8, 2024)'
       inputs:
         version: 6.0.x      
     - task: gitversion/setup@0
       displayName: 'Prepare'
       inputs:
-        versionSpec: '5.x'
+        versionSpec: '5.11.1'
     - task: gitversion/execute@0
       name: 'Version'
     - task: DotNetCoreCLI@2


### PR DESCRIPTION
Initial work to support SpecFlow v4.

- [x] support .NET Framework v4.6.2 (and above)
- [x] support .NET v6.0.0 (and above)
- [x] upgrade dependencies to latest

Note: this drops support for frameworks which are no longer maintained by Microsoft, i.e. .NET Framework v4.6.1, .NET Core v3.1 and .NET v5.0. See [.NET Framework Lifecycle Policy](https://learn.microsoft.com/en-us/lifecycle/products/microsoft-net-framework) and [.NET and .NET Core Lifecycle Policy](https://learn.microsoft.com/en-us/lifecycle/products/microsoft-net-and-net-core).
 