### PR TITLE
Feature: ServiceCollection extensible via scenario hooks

### DIFF
--- a/SpecFlow.DependencyInjection/SpecFlow.DependencyInjection.csproj
+++ b/SpecFlow.DependencyInjection/SpecFlow.DependencyInjection.csproj
@@ -32,7 +32,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="SpecFlow" Version="4.*-*" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="6.0.0" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="7.0.0" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>


### PR DESCRIPTION
`ServiceCollection`  will be read-only after creation of service provider - throws InvalidOperationException

Hi, I was evaluating you Plugin and I have found it almost applicable for my usage. The problem I found is, that the `[ScenarioDependencies]` can only be used once, and registrations to the ServiceCollection at a later point would just not be considered, as the `ServiceProvider` is created right after the `ServiceCollectionFinder` finished its job. 
As I am a provider of a library myself, I don't know which types will be registered by my libraries users, so I needed to provide a mechanism to do so. I decided that the use of the `ScenarioHooks` for `BeforeFeature`/`BeforeScenario` would be a way, as it's a known mechanism to change step bindings anyway.

I pushed the creation of the `ServiceProvider` further back into the `RootServiceProviderContainer`, and marked the `ServiceCollection` as read-only. (the reason why I copied over the contents of the `IServiceCollection` that is returned by the `ServiceCollectionFinder`)

Final words:
Maybe I am still missing out on some information and my changes are not necessary. But if turns out it is something that would improve your product, please feel free to use the code.

Thanks
R0boC0p