### PR TITLE
fix race condition causing bodi to throw exception

### DIFF
--- a/.idea/.idea.SpecFlow.DependencyInjection/.idea/.gitignore
+++ b/.idea/.idea.SpecFlow.DependencyInjection/.idea/.gitignore
@@ -1,0 +1,13 @@
+﻿# Default ignored files
+/shelf/
+/workspace.xml
+# Rider ignored files
+/.idea.SpecFlow.DependencyInjection.iml
+/contentModel.xml
+/projectSettingsUpdater.xml
+/modules.xml
+# Editor-based HTTP Client requests
+/httpRequests/
+# Datasource local storage ignored files
+/dataSources/
+/dataSources.local.xml

--- a/.idea/.idea.SpecFlow.DependencyInjection/.idea/encodings.xml
+++ b/.idea/.idea.SpecFlow.DependencyInjection/.idea/encodings.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="Encoding" addBOMForNewFiles="with BOM under Windows, with no BOM otherwise" />
+</project>

--- a/.idea/.idea.SpecFlow.DependencyInjection/.idea/indexLayout.xml
+++ b/.idea/.idea.SpecFlow.DependencyInjection/.idea/indexLayout.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="UserContentModel">
+    <attachedFolders />
+    <explicitIncludes />
+    <explicitExcludes />
+  </component>
+</project>

--- a/.idea/.idea.SpecFlow.DependencyInjection/.idea/vcs.xml
+++ b/.idea/.idea.SpecFlow.DependencyInjection/.idea/vcs.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="VcsDirectoryMappings">
+    <mapping directory="" vcs="Git" />
+  </component>
+</project>


### PR DESCRIPTION
Hi Everyone!

I've use this plugin with my test that contains around 14 testcases with multiple service registered ( Page object model, mostly) 
the plugin works fine with serquential execution but in parallelization, it failed with this signature
![image](https://github.com/solidtoken/SpecFlow.DependencyInjection/assets/8407412/e4ec9744-fe77-4ee8-9501-3e3bf6821667)
after dozen hour of debug, I discovered that the static method without lock is a problem so after I change it and run for a while, the problem seems to be gone.

I'm not sure that you can release this fix on v3.9 or not, but that would be cool as I will not need a clone of your code in my repo.

Cheers!